### PR TITLE
fix(monitoring): configure grafana persistence and external secret for admin password

### DIFF
--- a/argo-system-wave-1.yaml
+++ b/argo-system-wave-1.yaml
@@ -113,6 +113,13 @@ applications:
               ingressClassName: nginx
               hosts: [alertmanager.prosto.dev]
           grafana:
+            admin:
+              existingSecret: grafana-admin
+              userKey: admin-user
+              passwordKey: admin-password
+            persistence:
+              enabled: true
+              size: 10Gi
             ingress:
               enabled: true
               ingressClassName: nginx


### PR DESCRIPTION
Fixes #44.

**Root Cause:**
- Grafana pod was redeployed daily, likely due to Helm regenerating a random admin password during syncs, causing a checksum change in the pod template.
- Persistence was disabled (using `emptyDir`), so each restart wiped the data.

**Changes:**
- Enabled persistence for Grafana with a 10Gi PVC.
- Configured Grafana to use an existing secret (`grafana-admin`) for the admin user and password. This stabilizes the deployment, prevents random generation of passwords by Helm, and ensures consistent access.
